### PR TITLE
Use less invasive listchars settings

### DIFF
--- a/plugin/indentguides.vim
+++ b/plugin/indentguides.vim
@@ -46,9 +46,9 @@ function! s:ToggleIndentGuides(user_initiated)
     let g:original_listchars = get(g:, 'original_listchars', &g:listchars)
 
     " TODO: figure out why checking each addition individually breaks things for tab (unicode?)
-    let listchar_guides = ',tab:' . g:indentguides_tabchar . ' ,trail:·'
+    let listchar_guides = 'tab:' . g:indentguides_tabchar . ' ,trail:·,'
     if &g:listchars !~ listchar_guides
-      let &g:listchars = &g:listchars . listchar_guides
+      let &g:listchars = listchar_guides . &g:listchars
     endif
     setlocal concealcursor=inc
     setlocal conceallevel=2

--- a/plugin/indentguides.vim
+++ b/plugin/indentguides.vim
@@ -46,7 +46,7 @@ function! s:ToggleIndentGuides(user_initiated)
     let g:original_listchars = get(g:, 'original_listchars', &g:listchars)
 
     " TODO: figure out why checking each addition individually breaks things for tab (unicode?)
-    let listchar_guides = 'tab:' . g:indentguides_tabchar . ' ,trail:·,'
+    let listchar_guides = 'tab:' . g:indentguides_tabchar . ' ,'
     if &g:listchars !~ listchar_guides
       let &g:listchars = listchar_guides . &g:listchars
     endif


### PR DESCRIPTION
I noticed that indentguides was changing my listchar settings and there was no option to turn that off. Looking at the code, it doesn't seem like that was even necessary, so I'm proposing these 2 changes:

- Put indentguides' `listchar_guides` in the beginning of the listchars list, that way it doesn't override any user set listchars.
- Remove `trail` from listchar_guides since that's not being used (as far as I can tell) by this plugin.

This renders the `indentguides_tabchar` unnecessary since the user can set whatever character they want directly on their vimrc listchars, but I left it there for compatibility. 