### PR TITLE
Fixes #13: update g:indentguides_guidewidth when guides are toggled

### DIFF
--- a/plugin/indentguides.vim
+++ b/plugin/indentguides.vim
@@ -31,6 +31,7 @@ endfunction
 
 function! s:ToggleIndentGuides(user_initiated)
   let b:toggle_indentguides = get(b:, 'toggle_indentguides', 1)
+  let g:indentguides_guidewidth = &l:shiftwidth
 
   if !a:user_initiated
     if index(g:indentguides_ignorelist, &filetype) != -1 || !b:toggle_indentguides


### PR DESCRIPTION
This updates `g:indentguides_guidewith` when the guides are toggled. This enables compatibility between `vim-indentguides` and `vim-editorconfig` (and other similar plugins).