### PR TITLE
add default disable config variable (WIP)

### DIFF
--- a/plugin/indentguides.vim
+++ b/plugin/indentguides.vim
@@ -3,6 +3,12 @@
 " License: Apache 2.0
 " URL:     https://github.com/thaerkh/vim-indentguides
 
+" A sensible if case that allows the user to disable plugin by default via vimrc
+if exists('g:loaded_vim-indentguides')
+    finish
+endif
+let g:loaded_vim_indentguides = 1
+
 let g:indentguides_firstlevel = get(g:, 'indentguides_firstlevel', 0)
 let g:indentguides_ignorelist = get(g:, 'indentguides_ignorelist', [])
 let g:indentguides_spacechar = get(g:, 'indentguides_spacechar', '┆')


### PR DESCRIPTION
Addresses issue #12.
Also renamed global variable to: 'g:loaded_vim_indentguides' instead of 'g:loaded_vim-indentguides' because it did not work