### PR TITLE
Don't force conceallevel and concellcursor

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ let g:indentguides_spacechar = '┆'
 let g:indentguides_tabchar = '|'
 ```
 
+The plugin will set the conceallevel to '2 if' except if it is already set to '1' or '2'. If `concealcursor` it not modifed it will be set to `inc`, to disable this set it to an nonempty value or set `let g:indentguides_concealcursor_unaltered` to any nonempty value.
+
 # Installation
 
 ### Using Plug

--- a/plugin/indentguides.vim
+++ b/plugin/indentguides.vim
@@ -51,8 +51,12 @@ function! s:ToggleIndentGuides(user_initiated)
     if &g:listchars !~ listchar_guides
       let &g:listchars = &g:listchars . listchar_guides
     endif
-    setlocal concealcursor=inc
-    setlocal conceallevel=2
+    if &conceallevel == 0 || &conceallevel == 3
+      setlocal conceallevel=2
+    fi
+    if &concealcursor == "" && !exists('g:indentguides_concealcursor_unaltered')
+      setlocal concealcursor=inc
+    fi
     if g:indentguides_toggleListMode
       setlocal list
     endif

--- a/plugin/indentguides.vim
+++ b/plugin/indentguides.vim
@@ -53,10 +53,10 @@ function! s:ToggleIndentGuides(user_initiated)
     endif
     if &conceallevel == 0 || &conceallevel == 3
       setlocal conceallevel=2
-    fi
-    if &concealcursor == "" && !exists('g:indentguides_concealcursor_unaltered')
+    endif
+    if &concealcursor ==# '' && !exists('g:indentguides_concealcursor_unaltered')
       setlocal concealcursor=inc
-    fi
+    endif
     if g:indentguides_toggleListMode
       setlocal list
     endif


### PR DESCRIPTION
The plugin needs conceallevel to be set to 1 or 2 to work and
also sets concellcursor to 'inc' so that the markers are also visible
for the line of the cursor.

Since not everyone likes this behavior this commit changes the behavior:
- If conceallevel it set to 1, don't change it
- If concellcursor is nonempty, don't change it
- If concellcursor is empty but `g:indentguides_concealcursor_unaltered`
  is set, don't change it

This should be the best compromise of "works fully out of box" and "doesn't ignore users settings"